### PR TITLE
Add: default pencil mark on multiple cells selection

### DIFF
--- a/src/components/app/app.js
+++ b/src/components/app/app.js
@@ -127,7 +127,7 @@ function cellMouseOverHandler (e, setGrid) {
     }
 }
 
-function docKeyDownHandler (e, modalActive, setGrid, solved, inputMode) {
+function docKeyDownHandler (e, modalActive, setGrid, solved, inputMode, grid) {
     if (solved || modalActive) {
         return;
     }
@@ -147,13 +147,14 @@ function docKeyDownHandler (e, modalActive, setGrid, solved, inputMode) {
         digit = digitFromShiftNumKey[e.key];
     }
     if (digit !== undefined) {
+        const selectedCells = grid.get("cells").filter((c) => c.get("isSelected"));
         if ((e.shiftKey && ctrlOrMeta) || inputMode === 'color') {
             setGrid((grid) => modelHelpers.updateSelectedCells(grid, 'setCellColor', digit));
         }
         else if (ctrlOrMeta || inputMode === 'inner') {
             setGrid((grid) => modelHelpers.updateSelectedCells(grid, 'toggleInnerPencilMark', digit));
         }
-        else if (e.shiftKey || inputMode === 'outer') {
+        else if (e.shiftKey || inputMode === 'outer' || selectedCells.size > 1) {
             setGrid((grid) => modelHelpers.updateSelectedCells(grid, 'toggleOuterPencilMark', digit));
         }
         else {
@@ -460,7 +461,7 @@ function App() {
 
     useEffect(
         () => {
-            const pressHandler = (e) => docKeyDownHandler(e, modalActive, setGrid, solved, inputMode);
+            const pressHandler = (e) => docKeyDownHandler(e, modalActive, setGrid, solved, inputMode, grid);
             document.addEventListener('keydown', pressHandler);
             const releaseHandler = (e) => docKeyUpHandler(e, modalActive, setGrid);
             document.addEventListener('keyup', releaseHandler);
@@ -469,7 +470,7 @@ function App() {
                 document.removeEventListener('keyup', releaseHandler)
             };
         },
-        [solved, inputMode, modalActive]
+        [solved, inputMode, modalActive, grid]
     );
 
     useEffect(


### PR DESCRIPTION
#What I did was to check how many cells are selected and add the pencil mark if the size is more than 1.
I added an outer pencil because it seems more reasonable to me (usually the center pencil mark is for pairs which are more rare 😄 ), and also it's function the same as CTC app.
#19 